### PR TITLE
Bug fix: need to import mlbgame.events

### DIFF
--- a/mlbgame/__init__.py
+++ b/mlbgame/__init__.py
@@ -149,6 +149,7 @@ And the output is:
 """
 
 import sys
+import mlbgame.events
 import mlbgame.game
 import mlbgame.stats
 import calendar


### PR DESCRIPTION
Was getting the following error when trying to call `mlbgame.game_events()`:

```
In [7]: mlbgame.game_events(g.game_id)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-c92e9144e387> in <module>()
----> 1 mlbgame.game_events(g.game_id)

/usr/local/lib/python3.5/site-packages/mlbgame/__init__.py in game_events(game_id)
    265     Ex. events['inningnumber']['top/bottom'][atbatnumber]
    266     """
--> 267     data = mlbgame.events.game_events(game_id)
    268     output = {}
    269     for x in data:

AttributeError: module 'mlbgame' has no attribute 'events'
```

Looks like `mlbgame.events` needed to be imported into `__init__.py`